### PR TITLE
Fix google_maps_metrics_service

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -24,10 +24,10 @@ Rails.application.configure do
 
   # Show full error reports and disable caching.
   config.consider_all_requests_local       = true
-  config.action_controller.perform_caching = false
-  config.cache_store = :null_store
-  # config.action_controller.perform_caching = true
-  # config.cache_store = :memory_store
+  # config.action_controller.perform_caching = false
+  # config.cache_store = :null_store
+  config.action_controller.perform_caching = true
+  config.cache_store = :memory_store
 
   # Raise exceptions instead of rendering exception templates.
   config.action_dispatch.show_exceptions = false

--- a/spec/services/google_maps_metrics_service_spec.rb
+++ b/spec/services/google_maps_metrics_service_spec.rb
@@ -13,108 +13,139 @@ RSpec.describe GoogleMapsMetricsService, type: :service do
 
   describe "#fetch_distance_and_duration" do
     let(:service) { described_class.new(coordinates, coordinates) }
-    let(:result) { service.fetch_distance_and_duration }
+    let(:result) { VCR.use_cassette(cassette_path) { service.fetch_distance_and_duration } }
+    let(:cache_key) { "distance_metrics:#{coordinates.join("%2C")}_to_#{coordinates.join("%2C")}" }
+    let(:error_message) { Faker::Lorem.word }
+
+    shared_examples "calls the external API" do
+      it { expect(HTTParty).to have_received(:get).with(a_string_including(GoogleMapsMetricsService::BASE_URL)) }
+    end
+
+    before { allow(Rails.cache).to receive(:fetch).and_call_original }
+
+    context "when an unexpected error occurs" do
+      before { allow(service).to receive(:make_api_request).and_raise(StandardError, error_message) }
+
+      it "returns an error message" do
+        expect(service.fetch_distance_and_duration).
+          to include(message: a_string_including("#{error_message}"))
+      end
+
+      it "does NOT call the external API" do
+        expect(HTTParty).not_to receive(:get).
+          with(a_string_including(GoogleMapsMetricsService::BASE_URL))
+      end
+
+      it "checks the cache" do
+        service.fetch_distance_and_duration
+        expect(Rails.cache).to have_received(:fetch).
+          with(a_string_including("#{coordinates.join("%2C")}"), a_hash_including(:expires_in))
+      end
+    end
 
     context "when a cached response is available" do
+      let(:cache_response) { Faker::ChuckNorris.fact }
+
       before do
-        allow(Rails.cache).to receive(:fetch).and_call_original
-        result
+        Rails.cache.write(cache_key, cache_response)
+        allow(HTTParty).to receive(:get)
+        service.fetch_distance_and_duration
+      end
+
+      it "checks the cache" do
+        expect(Rails.cache).to have_received(:fetch).
+          with(a_string_including("#{coordinates.join("%2C")}"), a_hash_including(:expires_in))
       end
 
       it "retrieves the cached response" do
-        expect(Rails.cache).to have_received(:fetch).with(
-          a_string_including("#{coordinates.join("%2C")}"), a_hash_including(:expires_in)
-        )
+        expect(service.fetch_distance_and_duration).to eq(cache_response)
       end
 
-      it "doesn't call the external API" do
-        expect(HTTParty).not_to receive(:get)
+      it "does NOT call the external API" do
+        expect(HTTParty).not_to have_received(:get).
+          with(a_string_including(GoogleMapsMetricsService::BASE_URL))
       end
     end
 
     context "when a cached response is NOT available" do
-      before do
-        allow(Rails.cache).to receive(:fetch).and_call_original
-        allow(HTTParty).to receive(:get)
-        result
-      end
+      before { Rails.cache.delete(cache_key) }
 
-      it "caches the API response" do
-        expect(Rails.cache).to have_received(:fetch).with(
-          a_string_including("#{coordinates.join("%2C")}"), a_hash_including(:expires_in)
-        )
-      end
-
-      it "calls the external API" do
-        expect(HTTParty).to have_received(:get)
-      end
-    end
-
-    context "when the request to the API happens" do
-      let(:call_with_vcr) { VCR.use_cassette(cassette_path) { result } }
-
-      before do
-        allow(HTTParty).to receive(:get).and_return(expected_response)
-      end
-
-      context "when the request is successful" do
+      context "when the response is successful" do
         let(:cassette_path) { "successful_api_request" }
-        let(:expected_response) do
-          {
-            "status" => "OK",
-            "rows" => [{
-              "elements" => [{
-                "status" => "OK",
-                "distance" => { "text" => "10 miles" },
-                "duration" => { "text" => "30 mins" }
-              }]
-            }]
-          }
+        let(:expected_response) { instance_double(HTTParty::Response, success?: true, body: response_body) }
+
+        before do
+          allow(HTTParty).to receive(:get).and_return(expected_response)
+          result
         end
 
-        it "returns distance and duration" do
-          expect(call_with_vcr).to include(distance: "10 miles", duration: "30 mins")
+        context "when the response status is OK" do
+          let(:response_body) do
+            {
+              "status" => "OK",
+              "rows" => [{
+                "elements" => [{
+                  "status" => "OK",
+                  "distance" => { "text" => "10 miles" },
+                  "duration" => { "text" => "30 mins" }
+                }]
+              }]
+            }.to_json
+          end
+
+          it_behaves_like "calls the external API"
+
+          it "caches the API response" do
+            expect(Rails.cache.read(cache_key)).to eq(result)
+          end
+
+          it "returns distance and duration" do
+            expect(result).to include(distance: "10 miles", duration: "30 mins")
+          end
+        end
+
+        context "when the response status is NOT OK" do
+          let(:response_body) do
+            {
+              "status" => "REQUEST_DENIED",
+              "error_message" => "Invalid API key",
+            }.to_json
+          end
+
+          it_behaves_like "calls the external API"
+
+          it "does NOT cache the API response" do
+            expect(Rails.cache.read(cache_key)).to be_nil
+          end
+
+          it "returns an ERROR status with a message" do
+            expect(result).to include(status: "ERROR", message: a_string_including("REQUEST_DENIED", "Invalid API key"))
+          end
         end
       end
 
-      context "when the request fails" do
+      context "when the response is NOT successful" do
         let(:cassette_path) { "failed_api_request" }
+        let(:http_code) { Faker::Number.number(digits: 3) }
         let(:error_message) { Faker::Lorem.word }
-        let(:expected_response) do
-          {
-            "status" => "OK",
-            "rows" => [{
-              "elements" => [{
-                "status" => error_message
-              }]
-            }]
-          }
+        let(:expected_response) { instance_double(HTTParty::Response, success?: false, code: http_code) }
+
+        before do
+          allow(expected_response).to receive(:parsed_response).
+            and_return({ "error" => { "message" => error_message } })
+          allow(HTTParty).to receive(:get).and_return(expected_response)
+          result
         end
 
-        it "returns an error message" do
-          expect(call_with_vcr).to include(error: error_message)
+        it_behaves_like "calls the external API"
+
+        it "does NOT cache the API response" do
+          expect(Rails.cache.read(cache_key)).to be_nil
         end
-      end
 
-      context "when the API is down" do
-        let(:cassette_path) { nil }
-        let(:expected_response) { RuntimeError }
-
-        before { allow(HTTParty).to receive(:get).and_raise(RuntimeError)}
-
-        it "returns an error message" do
-          expect(call_with_vcr).to include(error: a_string_including("#{expected_response}"))
+        it "returns an ERROR status with a message" do
+          expect(result).to include(status: "ERROR", message: a_string_including(http_code.to_s, error_message))
         end
-      end
-    end
-
-    context "when an unexpected error occurs" do
-      let(:error_message) { Faker::Lorem.word }
-
-      before { allow(service).to receive(:make_api_request).and_raise(StandardError, error_message)}
-
-      it "returns an error message" do
-        expect(result).to include(error: a_string_including("#{error_message}"))
       end
     end
   end


### PR DESCRIPTION
broken logic in my service 🚨 

I noticed that I was saving in cache error responses from the external API, but that is no bueno, in my opinion, because if the error is about an API key being expired, for example, that is going to be saved in the cache and if the same cache_key comes in the service, then the output from fetch_distance_and_duration will be like `{ error: response["error_message"] }` and that doesn't help us to save information that isn't a valid `{ distance: @distance, duration: @duration }`

- now when there is an error from the external API, I raise the error, but then I just silently rescue it without caching the error paired with the cache_key
- also improved specs to match the other service address-verification-service spec
- unable caching things in `config/environments/test.rb` to have better tests of the cach